### PR TITLE
fix(release): reworks how latest release check works

### DIFF
--- a/pkg/cmd/version/releases.go
+++ b/pkg/cmd/version/releases.go
@@ -6,8 +6,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/google/go-github/v41/github"
 	"golang.org/x/net/context"
-
-	"github.com/bartoszmajsak/template-golang/version"
 )
 
 func LatestRelease() (string, error) {
@@ -24,6 +22,9 @@ func LatestRelease() (string, error) {
 	return *latestRelease.Name, nil
 }
 
-func IsLatestRelease(latestRelease string) bool {
-	return latestRelease == version.Version
+func IsLatestRelease(releaseVersion string) bool {
+	latestRelease, _ := LatestRelease()
+
+	return releaseVersion == latestRelease
 }
+

--- a/pkg/cmd/version/releases_test.go
+++ b/pkg/cmd/version/releases_test.go
@@ -14,6 +14,7 @@ var _ = Describe("Fetching latest release", func() {
 	BeforeEach(func() {
 		gock.New("https://api.github.com").
 			Get("/repos/bartoszmajsak/template-golang/releases/latest").
+			Persist().
 			Reply(200).
 			File("fixtures/latest_release_is_v.0.0.2.json")
 	})
@@ -33,11 +34,10 @@ var _ = Describe("Fetching latest release", func() {
 
 	It("should determine that v0.0.0 is not latest release", func() {
 		// given
-		latestRelease, err := version.LatestRelease()
-		Expect(err).ToNot(HaveOccurred())
+		currentVersion := v.Version
 
 		// when
-		latest := version.IsLatestRelease(latestRelease)
+		latest := version.IsLatestRelease(currentVersion)
 
 		// then
 		Expect(latest).To(BeFalse())


### PR DESCRIPTION
Fixes logic determining if passed version string is latest release.

Fixes #21
